### PR TITLE
refactor type hinting

### DIFF
--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -13,7 +13,7 @@ from rpdk.core.init import input_with_validation
 from rpdk.core.jsonutils.resolver import ContainerType, resolve_models
 from rpdk.core.plugin_base import LanguagePlugin
 
-from .resolver import models_in_properties, translate_type
+from .resolver import models_in_properties, resource_name_suffix, translate_type
 
 LOG = logging.getLogger(__name__)
 
@@ -42,6 +42,7 @@ class Python36LanguagePlugin(LanguagePlugin):
             trim_blocks=True, lstrip_blocks=True, keep_trailing_newline=True
         )
         self.env.filters["translate_type"] = translate_type
+        self.env.filters["resource_name_suffix"] = resource_name_suffix
         self.env.filters["models_in_properties"] = models_in_properties
         self.env.globals["ContainerType"] = ContainerType
         self.namespace = None

--- a/python/rpdk/python/resolver.py
+++ b/python/rpdk/python/resolver.py
@@ -9,10 +9,17 @@ PRIMITIVE_TYPES = {
 }
 
 
+def resource_name_suffix(name):
+    # add a suffix to prevent typing conflicts
+    if name != "ResourceModel":
+        return f"{name}ResourceModel"
+    return name
+
+
 def translate_type(resolved_type):
     if resolved_type.container == ContainerType.MODEL:
-        # we create type vars to make it easier to ref later models
-        return f"T{resolved_type.type}"
+        # quote types to ensure they can be ref'd
+        return f'"{resource_name_suffix(resolved_type.type)}"'
     if resolved_type.container == ContainerType.PRIMITIVE:
         return PRIMITIVE_TYPES[resolved_type.type]
 

--- a/python/rpdk/python/templates/handlers.py
+++ b/python/rpdk/python/templates/handlers.py
@@ -7,12 +7,11 @@ from {{support_lib_pkg}} import (
     OperationStatus,
     ProgressEvent,
     Resource,
-    ResourceHandlerRequest,
     SessionProxy,
     exceptions,
 )
 
-from .models import ResourceModel, TResourceModel
+from .models import ResourceHandlerRequest, ResourceModel
 
 # Use this logger to forward log messages to CloudWatch Logs.
 LOG = logging.getLogger(__name__)
@@ -24,11 +23,11 @@ test_entrypoint = resource.test_entrypoint
 @resource.handler(Action.CREATE)
 def create_handler(
     session: Optional[SessionProxy],
-    request: ResourceHandlerRequest[TResourceModel],
+    request: ResourceHandlerRequest,
     callback_context: MutableMapping[str, Any],
-) -> ProgressEvent[TResourceModel]:
+) -> ProgressEvent:
     model = request.desiredResourceState
-    progress: ProgressEvent[TResourceModel] = ProgressEvent(
+    progress: ProgressEvent = ProgressEvent(
         status=OperationStatus.IN_PROGRESS,
         resourceModel=model,
     )
@@ -51,11 +50,11 @@ def create_handler(
 @resource.handler(Action.UPDATE)
 def update_handler(
     session: Optional[SessionProxy],
-    request: ResourceHandlerRequest[TResourceModel],
+    request: ResourceHandlerRequest,
     callback_context: MutableMapping[str, Any],
-) -> ProgressEvent[TResourceModel]:
+) -> ProgressEvent:
     model = request.desiredResourceState
-    progress: ProgressEvent[TResourceModel] = ProgressEvent(
+    progress: ProgressEvent = ProgressEvent(
         status=OperationStatus.IN_PROGRESS,
         resourceModel=model,
     )
@@ -66,11 +65,11 @@ def update_handler(
 @resource.handler(Action.DELETE)
 def delete_handler(
     session: Optional[SessionProxy],
-    request: ResourceHandlerRequest[TResourceModel],
+    request: ResourceHandlerRequest,
     callback_context: MutableMapping[str, Any],
-) -> ProgressEvent[TResourceModel]:
+) -> ProgressEvent:
     model = request.desiredResourceState
-    progress: ProgressEvent[TResourceModel] = ProgressEvent(
+    progress: ProgressEvent = ProgressEvent(
         status=OperationStatus.IN_PROGRESS,
         resourceModel=model,
     )
@@ -81,9 +80,9 @@ def delete_handler(
 @resource.handler(Action.READ)
 def read_handler(
     session: Optional[SessionProxy],
-    request: ResourceHandlerRequest[TResourceModel],
+    request: ResourceHandlerRequest,
     callback_context: MutableMapping[str, Any],
-) -> ProgressEvent[TResourceModel]:
+) -> ProgressEvent:
     model = request.desiredResourceState
     # TODO: put code here
     return ProgressEvent(
@@ -95,9 +94,9 @@ def read_handler(
 @resource.handler(Action.LIST)
 def list_handler(
     session: Optional[SessionProxy],
-    request: ResourceHandlerRequest[TResourceModel],
+    request: ResourceHandlerRequest,
     callback_context: MutableMapping[str, Any],
-) -> ProgressEvent[TResourceModel]:
+) -> ProgressEvent:
     # TODO: put code here
     return ProgressEvent(
         status=OperationStatus.SUCCESS,

--- a/src/aws_cloudformation_rpdk_python_lib/__init__.py
+++ b/src/aws_cloudformation_rpdk_python_lib/__init__.py
@@ -3,10 +3,10 @@ import logging
 from .boto3_proxy import SessionProxy  # noqa: F401
 from .interface import (  # noqa: F401
     Action,
+    BaseResourceHandlerRequest,
     HandlerErrorCode,
     OperationStatus,
     ProgressEvent,
-    ResourceHandlerRequest,
 )
 from .resource import Resource  # noqa: F401
 

--- a/src/aws_cloudformation_rpdk_python_lib/exceptions.py
+++ b/src/aws_cloudformation_rpdk_python_lib/exceptions.py
@@ -1,34 +1,34 @@
-from typing import Any, Generic
+from typing import Any
 
-from .interface import HandlerErrorCode, ProgressEvent, T
+from .interface import HandlerErrorCode, ProgressEvent
 
 
-class _HandlerError(Exception, Generic[T]):
+class _HandlerError(Exception):
     def __init__(self, *args: Any):
         self._error_code = HandlerErrorCode[type(self).__name__]
         super().__init__(*args)
 
-    def to_progress_event(self) -> ProgressEvent[T]:
+    def to_progress_event(self) -> ProgressEvent:
         return ProgressEvent.failed(self._error_code, str(self))
 
 
-class NotUpdatable(_HandlerError[T]):
+class NotUpdatable(_HandlerError):
     pass
 
 
-class InvalidRequest(_HandlerError[T]):
+class InvalidRequest(_HandlerError):
     pass
 
 
-class AccessDenied(_HandlerError[T]):
+class AccessDenied(_HandlerError):
     pass
 
 
-class InvalidCredentials(_HandlerError[T]):
+class InvalidCredentials(_HandlerError):
     pass
 
 
-class AlreadyExists(_HandlerError[T]):
+class AlreadyExists(_HandlerError):
     def __init__(self, type_name: str, identifier: str):
         super().__init__(
             f"Resource of type '{type_name}' with identifier "
@@ -36,7 +36,7 @@ class AlreadyExists(_HandlerError[T]):
         )
 
 
-class NotFound(_HandlerError[T]):
+class NotFound(_HandlerError):
     def __init__(self, type_name: str, identifier: str):
         super().__init__(
             f"Resource of type '{type_name}' with identifier "
@@ -44,33 +44,33 @@ class NotFound(_HandlerError[T]):
         )
 
 
-class ResourceConflict(_HandlerError[T]):
+class ResourceConflict(_HandlerError):
     pass
 
 
-class Throttling(_HandlerError[T]):
+class Throttling(_HandlerError):
     pass
 
 
-class ServiceLimitExceeded(_HandlerError[T]):
+class ServiceLimitExceeded(_HandlerError):
     pass
 
 
-class NotStabilized(_HandlerError[T]):
+class NotStabilized(_HandlerError):
     pass
 
 
-class GeneralServiceException(_HandlerError[T]):
+class GeneralServiceException(_HandlerError):
     pass
 
 
-class ServiceInternalError(_HandlerError[T]):
+class ServiceInternalError(_HandlerError):
     pass
 
 
-class NetworkFailure(_HandlerError[T]):
+class NetworkFailure(_HandlerError):
     pass
 
 
-class InternalFailure(_HandlerError[T]):
+class InternalFailure(_HandlerError):
     pass

--- a/src/aws_cloudformation_rpdk_python_lib/utils.py
+++ b/src/aws_cloudformation_rpdk_python_lib/utils.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 from datetime import date, datetime, time
 from typing import Any, Mapping, MutableMapping, Optional, Type
 
-from .interface import Action, ResourceHandlerRequest, T
+from .interface import Action, BaseResourceHandlerRequest, BaseResourceModel
 
 
 class KitchenSinkEncoder(json.JSONEncoder):
@@ -93,16 +93,14 @@ class UnmodelledRequest:
     logicalResourceIdentifier: Optional[str] = None
     nextToken: Optional[str] = None
 
-    def to_modelled(self, model_cls: Type[T]) -> ResourceHandlerRequest[T]:
+    def to_modelled(
+        self, model_cls: Type[BaseResourceModel]
+    ) -> BaseResourceHandlerRequest:
         # pylint: disable=protected-access
-        return ResourceHandlerRequest(
+        return BaseResourceHandlerRequest(
             clientRequestToken=self.clientRequestToken,
-            desiredResourceState=model_cls._deserialize(  # type: ignore
-                self.desiredResourceState
-            ),
-            previousResourceState=model_cls._deserialize(  # type: ignore
-                self.previousResourceState
-            ),
+            desiredResourceState=model_cls._deserialize(self.desiredResourceState),
+            previousResourceState=model_cls._deserialize(self.previousResourceState),
             logicalResourceIdentifier=self.logicalResourceIdentifier,
             nextToken=self.nextToken,
         )

--- a/tests/lib/interface_test.py
+++ b/tests/lib/interface_test.py
@@ -5,6 +5,7 @@ from string import ascii_letters
 import boto3
 import pytest
 from aws_cloudformation_rpdk_python_lib.interface import (
+    BaseResourceModel,
     HandlerErrorCode,
     OperationStatus,
     ProgressEvent,
@@ -23,6 +24,16 @@ def client():
         aws_session_token="",
         region_name="us-east-1",
     )
+
+
+def test_base_resource_model__deserialize():
+    with pytest.raises(NotImplementedError):
+        BaseResourceModel()._deserialize({})
+
+
+def test_base_resource_model__serialize():
+    brm = BaseResourceModel()
+    assert brm._serialize() == brm.__dict__
 
 
 @given(s.sampled_from(HandlerErrorCode), s.text(ascii_letters))

--- a/tests/plugin/resolver_test.py
+++ b/tests/plugin/resolver_test.py
@@ -13,7 +13,12 @@ RESOLVED_TYPES = [
 
 def test_translate_type_model_typevar():
     traslated = translate_type(ResolvedType(ContainerType.MODEL, "Foo"))
-    assert traslated == "TFoo"
+    assert traslated == '"FooResourceModel"'
+
+
+def test_translate_type_model_typevar_main_resource_model():
+    traslated = translate_type(ResolvedType(ContainerType.MODEL, "ResourceModel"))
+    assert traslated == '"ResourceModel"'
 
 
 @pytest.mark.parametrize("resolved_type,native_type", RESOLVED_TYPES)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Main aim of this pr is to simplify the representation of type hints in the handler and improve IDE resolution of types for inline hinting/validation.

A notable sacrifice was that I had to set the type for the `ResourceHandlerRequest` in `HandlerSignature` to `Any` to get mypy to accept that the actual handler was using `ResourceHandlerRequest` not `BaseResourceHandlerRequest`.

Previously PyCharm (didn't test other IDE's) was not able to resolve types for `ResourceModel` or `ProgressEvent`. Type completion/validation now works as expected.

![2019-11-08_13-53-42](https://user-images.githubusercontent.com/20962883/68513244-6043dc80-022f-11ea-922f-8c2ffd7260ff.gif)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
