### PR TITLE
enable local and cloudwatch handler re-invocation while IN_PROGRESS

### DIFF
--- a/src/cloudformation_cli_python_lib/utils.py
+++ b/src/cloudformation_cli_python_lib/utils.py
@@ -121,5 +121,5 @@ class UnmodelledRequest:
 
 
 class LambdaContext:
-    get_remaining_time_in_millis: Callable[[Any], int]
+    get_remaining_time_in_millis: Callable[["LambdaContext"], int]
     invoked_function_arn: str

--- a/src/cloudformation_cli_python_lib/utils.py
+++ b/src/cloudformation_cli_python_lib/utils.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import dataclass, field
 from datetime import date, datetime, time
-from typing import Any, Mapping, MutableMapping, Optional, Type
+from typing import Any, Callable, Mapping, MutableMapping, Optional, Type
 
 from .interface import Action, BaseResourceHandlerRequest, BaseResourceModel
 
@@ -118,3 +118,8 @@ class UnmodelledRequest:
             logicalResourceIdentifier=self.logicalResourceIdentifier,
             nextToken=self.nextToken,
         )
+
+
+class LambdaContext:
+    get_remaining_time_in_millis: Callable[[Any], int]
+    invoked_function_arn: str

--- a/tests/lib/resource_test.py
+++ b/tests/lib/resource_test.py
@@ -313,9 +313,7 @@ def test_test_entrypoint_success():
     mock_model._deserialize.side_effect = [None, None]
 
     resource = Resource(mock_model)
-    progress_event = Mock(
-        "cloudformation_cli_python_lib.interface.ProgressEvent", autospec=True
-    )()
+    progress_event = ProgressEvent(status=OperationStatus.SUCCESS)
     mock_handler = resource.handler(Action.CREATE)(Mock(return_value=progress_event))
 
     payload = {


### PR DESCRIPTION
*Issue #, if available:* #57

*Description of changes:*

doesn't include [reportProgress](https://github.com/aws-cloudformation/aws-cloudformation-rpdk-java-plugin/blob/master/src/main/java/software/amazon/cloudformation/proxy/CloudFormationCallbackAdapter.java#L51-L83) which will come in a future pr.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
